### PR TITLE
MRTI-3163 # Add Advanced search endpoint

### DIFF
--- a/datalake_scripts/__init__.py
+++ b/datalake_scripts/__init__.py
@@ -1,0 +1,5 @@
+from .common import base_script
+
+from .engines import get_engine, post_engine
+from .engines.get_engine import *
+from .engines.post_engine import *

--- a/datalake_scripts/config/endpoints.json
+++ b/datalake_scripts/config/endpoints.json
@@ -7,6 +7,7 @@
     "bulk-search": "mrti/bulk-search/",
     "retrieve-bulk-search": "mrti/bulk-search/task/{task_uuid}/",
     "threats": "mrti/threats/",
+    "advanced-search": "mrti/advanced-queries/threats/",
     "threats-manual": "mrti/threats-manual/",
     "threats-manual-bulk": "mrti/bulk-manual-threats/",
     "retrieve-threats-manual-bulk": "mrti/bulk-manual-threats/task/{task_uuid}/",

--- a/datalake_scripts/engines/get_engine.py
+++ b/datalake_scripts/engines/get_engine.py
@@ -88,3 +88,21 @@ class LookupThreats(GetEngine):
             complete_response = {} if not complete_response else complete_response
             complete_response[threat] = response
         return complete_response
+
+
+class Threats(GetEngine):
+    """Retrieve threats based on an query hash using the Advanced Search endpoint
+    The endpoint limit the number of result to 5 000 threats but allow more output than the bulk search
+    """
+
+    def _build_url(self, endpoint_config: dict, environment: str):
+        return self._build_url_for_endpoint('advanced-search')
+
+    def get_threats(self, query_hash: str, limit=10, response_format="application/json") -> dict:
+        url = self.url + query_hash
+        params = {'limit': limit}
+        req = PreparedRequest()  # Adding parameters using requests' tool
+        req.prepare_url(url, params)
+        headers = {'Authorization': self.tokens[0], 'Accept': response_format}
+        response = self.datalake_requests(req.url, 'get', headers=headers)
+        return response

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='datalake-scripts',
-    version='2.1.1',
+    version='2.2.0',
     author='OCD',
     author_email='cert-contact.ocd@orange.com',
     description='A collection of scripts to easily use the API of OCD Datalake',


### PR DESCRIPTION
Add the advanced-search endpoint to be used in https://github.com/cert-orangecyberdefense/datalake_misp_integration (with the misp output format).

I don't know what to put in the `__init__.py` to allow this repo to be used as a library, so feel free to help :)