### PR TITLE
Feature/mrti 3350 Adapt query body to new advanced search

### DIFF
--- a/datalake_scripts/engines/post_engine.py
+++ b/datalake_scripts/engines/post_engine.py
@@ -70,8 +70,8 @@ class PostEngine(BaseEngine):
 
     @staticmethod
     def build_full_query_body(query_body):
-        if not isinstance(query_body, dict) or not query_body.get('AND'):
-            query_body = {"AND": query_body}  # Add top level AND if needed
+        if not isinstance(query_body, dict):
+            raise ValueError('query body must be full and valid')
         return query_body
 
 

--- a/tests/test_advanced_search_engine.py
+++ b/tests/test_advanced_search_engine.py
@@ -13,12 +13,7 @@ query_body_template = [
 ]
 
 
-@pytest.mark.parametrize('query_body', [
-    query_body_template,  # Query body as returned in the GUI
-    {'AND': [{'AND': query_body_template}]},  # Full query body
-])
-@responses.activate
-def test_split_list(tokens, query_body):
+def make_advanced_search_request(query_body, tokens):
     def request_callback(request):
         payload = json.loads(request.body)
         resp_body = response_template
@@ -27,7 +22,7 @@ def test_split_list(tokens, query_body):
         return 200, headers, json.dumps(resp_body)
 
     response_template = {
-        'count': 2, 'query_body': {'AND': query_body},
+        'count': 2, 'query_body': query_body,
         'query_hash': 'de70393f1c250ae67566ec37c2032d1b',
         'href_query': 'https://datalake.com/api/v42/mrti/advanced-queries/threats/de70393f1c250ae67566ec37c2032d1b/',
         'results': []
@@ -42,7 +37,22 @@ def test_split_list(tokens, query_body):
 
     advanced_search = AdvancedSearch(TEST_CONFIG, environment=TEST_ENV, tokens=tokens)
     response = advanced_search.get_threats(query_body=query_body, limit=0)
+    return response
+
+
+@responses.activate
+def test_full_query_body_request(tokens):
+    query_body = {'AND': [{'AND': query_body_template}]}  # Full query body
+    response = make_advanced_search_request(query_body, tokens)
 
     assert response['query_body']['AND'], 'query body must have a top level AND'
-    assert response['query_body'] == {'AND': query_body_template}, 'query body must be full'
+    assert response['query_body'] == {'AND': [{'AND': query_body_template}]}, 'query body must be full'
     assert response['query_hash'] == 'de70393f1c250ae67566ec37c2032d1b'
+
+
+@responses.activate
+def test_minimal_query_body_no_longer_accepted(tokens):
+    query_body = query_body_template  # Query body as previously returned in the GUI
+    with pytest.raises(ValueError) as ve:
+        make_advanced_search_request(query_body, tokens)
+    assert str(ve.value) == 'query body must be full and valid'

--- a/tests/test_advanced_search_engine.py
+++ b/tests/test_advanced_search_engine.py
@@ -15,7 +15,7 @@ query_body_template = [
 
 @pytest.mark.parametrize('query_body', [
     query_body_template,  # Query body as returned in the GUI
-    {'AND': query_body_template},  # Full query body
+    {'AND': [{'AND': query_body_template}]},  # Full query body
 ])
 @responses.activate
 def test_split_list(tokens, query_body):


### PR DESCRIPTION
Previously we tried to interpret a list of filters as an AND field, now we'll just reject it.