### PR TITLE
hotfix/MRTI-3516 # lookup_threats inconsistency

### DIFF
--- a/datalake_scripts/cli.py
+++ b/datalake_scripts/cli.py
@@ -64,7 +64,7 @@ The most commonly used {self.CLI_NAME} commands are:
         args = sys.argv[2:]
         add_tags.main(args)
 
-    def lookup_threat(self):
+    def lookup_threats(self):
         args = sys.argv[2:]
         lookup_threats.main(args)
 


### PR DESCRIPTION
Currently the command is named `lookup_threat` but in fact you can lookup multiple ones, so the change is made on the command name instead of modify the documentation.

From now the command will be called `lookup_threats`
