### PR TITLE
feature/MRTI-3575 ioc-collect command

### DIFF
--- a/datalake_scripts/cli.py
+++ b/datalake_scripts/cli.py
@@ -5,7 +5,7 @@ import sys
 
 from datalake_scripts.common.base_script import BaseScripts
 from datalake_scripts.scripts import add_threats, get_threats_by_hashkey, edit_score, get_threats_from_query_hash, \
-    add_comments, lookup_threats, add_tags, get_query_hash, iocs_select_hashkeys, iocs_select_uids
+    add_comments, lookup_threats, add_tags, get_query_hash, iocs_select_hashkeys, iocs_select_uids, iocs_collect
 
 
 class Cli:
@@ -75,6 +75,10 @@ The most commonly used {self.CLI_NAME} commands are:
     def iocs_select_uids(self):
         args = sys.argv[2:]
         iocs_select_uids.main(args)
+
+    def iocs_collect(self):
+        args = sys.argv[2:]
+        iocs_collect.main(args)
 
     def _list_commands_available(self):
         method_list = []

--- a/datalake_scripts/scripts/iocs_collect.py
+++ b/datalake_scripts/scripts/iocs_collect.py
@@ -1,0 +1,90 @@
+import argparse
+import logging
+import subprocess
+import sys
+
+from datalake_scripts.common.logger import configure_logging
+from datalake_scripts.common.logger import logger
+from datalake_scripts.scripts import iocs_select_hashkeys
+from datalake_scripts.scripts.iocs_select_hashkeys import make_output_file_name
+
+
+def main(override_args=None):
+    """Method to start the script"""
+    configure_logging(logging.DEBUG)
+    parser = _set_up_args()
+
+    if override_args:
+        args = parser.parse_args(override_args)
+    else:
+        args = parser.parse_args()
+
+    for args.threat_type in args.threat_types:
+        for args.atom_type in args.atom_types:
+            for args.min_score, args.max_score in args.score_ranges:
+                hashkeys_cmd = f'ocd-dtl iocs_select_hashkeys ' \
+                               f'--from-date {args.from_date} --to-date {args.to_date} ' \
+                               f'--threat-type {args.threat_type} --atom-type {args.atom_type} ' \
+                               f'--min-score {args.min_score} --max-score {args.max_score} ' \
+                               f'--max-samples {args.max_samples}'
+                logger.info(hashkeys_cmd)
+                subprocess.run(hashkeys_cmd, shell=True)
+
+                hashkey_output_filename = make_output_file_name(args)
+                uids_cmd = f'ocd-dtl iocs_select_uids ' \
+                           f'--file {hashkey_output_filename} --max-duration {args.max_duration}'
+                logger.info(uids_cmd)
+                subprocess.run(uids_cmd, shell=True)
+
+
+def _set_up_args():
+    """ this method set flags and args up for `iocs_select_hashkeys` command """
+    parser = argparse.ArgumentParser(description='execute `iocs_select_hashkeys` and `iocs_select_uids` with all '
+                                                 'possible permutations taken from arguments')
+
+    parser.add_argument('-t1', '--from-date', required=True, help='date from which hashkeys are selected YYYY-mm-dd')
+    parser.add_argument('-t2', '--to-date', required=True, help='date until hashkeys are selected YYYY-mm-dd')
+    parser.add_argument('-N', '--max-samples', required=True, type=int, help='max number of hashkeys to select')
+    parser.add_argument('-M', '--max-duration', required=True, type=int, help='max duration in days')
+
+    parser.add_argument(
+        '-e',
+        '--env',
+        help='execute on specified environment [Default: prod]',
+        choices=['prod', 'dtl2', 'preprod'],
+        default='prod',
+    )
+    parser.add_argument(
+        '-T',
+        '--threat-types',
+        nargs='+',
+        required=True,
+        help='threat types to select',
+        choices=iocs_select_hashkeys.SUPPORTED_THREAT_TYPES
+    )
+    parser.add_argument(
+        '-A',
+        '--atom-types',
+        nargs='+',
+        required=True,
+        help='threat type to select',
+        choices=iocs_select_hashkeys.SUPPORTED_ATOM_TYPES
+    )
+    parser.add_argument(
+        '-S',
+        '--score-ranges',
+        nargs='+',
+        required=True,
+        type=score_range_type,
+        help='score ranges min-1,max-1 min-2,max-2 min-3,max-3 ...'
+    )
+    return parser
+
+
+def score_range_type(value):
+    min_score, max_score = map(int, value.split(','))
+    return min_score, max_score
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/datalake_scripts/scripts/iocs_select_hashkeys.py
+++ b/datalake_scripts/scripts/iocs_select_hashkeys.py
@@ -40,7 +40,7 @@ def main(override_args=None):
     hashkeys = [result['hashkey'] for result in response['results']]
 
     if hashkeys:
-        filename = _make_output_file_name(args)
+        filename = make_output_file_name(args)
         starter.save_output(filename, hashkeys)
         logger.info(f'results saved in {filename}')
     else:
@@ -167,7 +167,7 @@ def _build_query_body(args):
     }
 
 
-def _make_output_file_name(args):
+def make_output_file_name(args):
     date_range = f'{args.from_date}_{args.to_date}'
     score_range = f'{args.min_score}_{args.max_score}'
 


### PR DESCRIPTION
## `ioc_collect` command


The idea behind this command is to execute multiple times with a given set of parameters creating all possible permutations. 
This command execute both `iocs_select_hashkeys` and `iocs_select_uids`

command structure

```sh
ocd-dtl iocs_collect
  --from-fate          YYYY-MM-dd
  --to-date            YYYY-MM-dd
  --max-samples        N
  --max-days-duration  M
  --threat-types       [ ... THEAT TYPES ]
  --atom-types         [ ... ATOM TYPES ]
  --score-ranges       [ ... (MIN, MAX)]
```

## example

```sh
ocd-dtl iocs_collect   --from-date 2021-05-01  --to-date 2021-05-15 --max-samples 10 --max-duration 5 --threat-types malware ddos --atom-types ip url --score-ranges 10,20 30,50
```

Under the hoods this should execute iocs_select_hashkeys and iocs_select_uids for its permutations:

* malware ip     10,20
* malware  ip     30,50
* malware  url   10,20
* malware  url   30,50
* ddos         ip     10,20
* ddos         ip     30,50
* ddos         url   10,20
* ddos         url   30,50
