### PR TITLE
MRTI-3632 # hotfix cli without args

### DIFF
--- a/datalake_scripts/cli.py
+++ b/datalake_scripts/cli.py
@@ -37,10 +37,11 @@ The most commonly used {self.CLI_NAME} commands are:
             print(self.VERSION)
             exit(0)
 
-        if not hasattr(self, args.command):
+        if not args.command or not hasattr(self, args.command):
             print('Unrecognized command')
             parser.print_help()
             exit(1)
+
         # use dispatch pattern to invoke method with same name
         getattr(self, args.command)()
 

--- a/datalake_scripts/cli.py
+++ b/datalake_scripts/cli.py
@@ -10,7 +10,7 @@ from datalake_scripts.scripts import add_threats, get_threats_by_hashkey, edit_s
 
 class Cli:
     CLI_NAME = BaseScripts.PACKAGE_NAME
-    VERSION = '2.3.2'
+    VERSION = '2.3.3'
 
     def __init__(self):
         parser = argparse.ArgumentParser(


### PR DESCRIPTION
call `cli` without args will print the command `help`