### PR TITLE
Feature/mrti 4270 Display GUI link returned by the bulklookup endpoint

### DIFF
--- a/datalake/endpoints/threats.py
+++ b/datalake/endpoints/threats.py
@@ -39,6 +39,7 @@ class Threats(Endpoint):
 
         body: dict = typed_atoms
         body['hashkey_only'] = hashkey_only
+        body['return_search_hashkey'] = True
         url = self._build_url_for_endpoint('threats-bulk-lookup')
         response = self.datalake_requests(url, 'post', self._post_headers(output=output), body)
         return parse_response(response)

--- a/datalake/endpoints/threats.py
+++ b/datalake/endpoints/threats.py
@@ -23,7 +23,7 @@ class Threats(Endpoint):
             atom_type: AtomType = None,
             hashkey_only=False,
             output=Output.JSON,
-            return_search_hashkey=False
+            return_search_hashkey=False,
     ) -> dict:
         """Bulk lookup done on maximum _NB_ATOMS_PER_BULK_LOOKUP atoms"""
         typed_atoms = {}
@@ -52,7 +52,7 @@ class Threats(Endpoint):
             atom_type: AtomType = None,
             hashkey_only=False,
             output=Output.JSON,
-            return_search_hashkey=False
+            return_search_hashkey=False,
     ) -> Union[dict, str]:
         """
         Look up multiple threats at once in the API, returning their ids and if they are present in Datalake.
@@ -69,13 +69,12 @@ class Threats(Endpoint):
                                                    output,
                                                    return_search_hashkey)
             if 'search_hashkey' in batch_result:
-                search_hashkey_list.append(batch_result['search_hashkey'])
-                batch_result.pop('search_hashkey')
+                search_hashkey_list.append(batch_result.pop('search_hashkey'))
             aggregated_response = aggregate_csv_or_json_api_response(
                 aggregated_response,
                 batch_result,
             )
-        if len(search_hashkey_list) > 0:
+        if search_hashkey_list:
             aggregated_response['search_hashkey'] = search_hashkey_list
         if output is Output.CSV:
             aggregated_response = '\n'.join(aggregated_response)  # a string is expected for CSV output

--- a/datalake/endpoints/threats.py
+++ b/datalake/endpoints/threats.py
@@ -22,7 +22,8 @@ class Threats(Endpoint):
             atom_values: list,
             atom_type: AtomType = None,
             hashkey_only=False,
-            output=Output.JSON
+            output=Output.JSON,
+            return_search_hashkey=False
     ) -> dict:
         """Bulk lookup done on maximum _NB_ATOMS_PER_BULK_LOOKUP atoms"""
         typed_atoms = {}
@@ -39,7 +40,7 @@ class Threats(Endpoint):
 
         body: dict = typed_atoms
         body['hashkey_only'] = hashkey_only
-        body['return_search_hashkey'] = True
+        body['return_search_hashkey'] = return_search_hashkey
         url = self._build_url_for_endpoint('threats-bulk-lookup')
         response = self.datalake_requests(url, 'post', self._post_headers(output=output), body)
         return parse_response(response)
@@ -50,7 +51,8 @@ class Threats(Endpoint):
             atom_values: list,
             atom_type: AtomType = None,
             hashkey_only=False,
-            output=Output.JSON
+            output=Output.JSON,
+            return_search_hashkey=False
     ) -> Union[dict, str]:
         """
         Look up multiple threats at once in the API, returning their ids and if they are present in Datalake.
@@ -59,12 +61,22 @@ class Threats(Endpoint):
         However, fewer outputs types are supported as of now.
         """
         aggregated_response = [] if output is Output.CSV else {}
+        search_hashkey_list = []
         for atom_values_batch in split_list(atom_values, self._NB_ATOMS_PER_BULK_LOOKUP):
-            batch_result = self._bulk_lookup_batch(atom_values_batch, atom_type, hashkey_only, output)
+            batch_result = self._bulk_lookup_batch(atom_values_batch,
+                                                   atom_type,
+                                                   hashkey_only,
+                                                   output,
+                                                   return_search_hashkey)
+            if 'search_hashkey' in batch_result:
+                search_hashkey_list.append(batch_result['search_hashkey'])
+                batch_result.pop('search_hashkey')
             aggregated_response = aggregate_csv_or_json_api_response(
                 aggregated_response,
                 batch_result,
             )
+        if len(search_hashkey_list) > 0:
+            aggregated_response['search_hashkey'] = search_hashkey_list
         if output is Output.CSV:
             aggregated_response = '\n'.join(aggregated_response)  # a string is expected for CSV output
         return aggregated_response

--- a/datalake_scripts/scripts/bulk_lookup_threats.py
+++ b/datalake_scripts/scripts/bulk_lookup_threats.py
@@ -212,7 +212,7 @@ def pretty_print(raw_response, stdout_format, env, dtl):
     elif search_hashkeys and len(search_hashkeys) > 10:
         logger.info('Too many search hashkeys to display, check the output for the full list.')
     else:
-        logger.info('No search haskeys available for this lookup.')
+        logger.info('No search hashkeys available for this lookup.')
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/datalake_scripts/scripts/bulk_lookup_threats.py
+++ b/datalake_scripts/scripts/bulk_lookup_threats.py
@@ -185,8 +185,7 @@ def pretty_print(raw_response, stdout_format, env, dtl):
         logger.info(raw_response)
         return
 
-    search_hashkeys = raw_response['search_hashkey'] if 'search_hashkey' in raw_response else None
-    raw_response.pop('search_hashkey')
+    search_hashkeys = raw_response.pop('search_hashkey', None)
     blue_bg = '\033[104m'
     eol = '\x1b[0m'
     boolean_to_text_and_color = {
@@ -210,9 +209,10 @@ def pretty_print(raw_response, stdout_format, env, dtl):
         for search_hashkey in search_hashkeys:
             url = base_url + search_hashkey
             logger.info(f'Results available here : {url}')
+    elif search_hashkeys and len(search_hashkeys) > 10:
+        logger.info('Too many search hashkeys to display, check the output for the full list.')
     else:
-        logger.info('To many search hashkeys to display, check the output for the full list.')
-
+        logger.info('No search haskeys available for this lookup.')
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/datalake_scripts/scripts/bulk_lookup_threats.py
+++ b/datalake_scripts/scripts/bulk_lookup_threats.py
@@ -1,11 +1,14 @@
 import json
 import sys
+import logging
 
+from halo import Halo
 from datalake import Datalake, AtomType, Output
 from datalake.common.logger import logger
 from datalake.common.utils import join_dicts, aggregate_csv_or_json_api_response
 from datalake_scripts.common.base_script import BaseScripts
 from datalake_scripts.helper_scripts.utils import split_input_file, save_output
+from urllib.parse import urlparse, urlsplit, urlunsplit
 
 SUBCOMMAND_NAME = 'bulk_lookup_threats'
 UNTYPED_ATOM_TYPE = 'untyped'
@@ -63,7 +66,6 @@ def main(override_args=None):
         except KeyError:
             logger.error('Not supported output, please use either json or csv')
             exit(1)
-
     # to gather all typed atoms passed by arguments and input files
     typed_atoms = {}
 
@@ -81,6 +83,10 @@ def main(override_args=None):
 
     # load api_endpoints and tokens
     dtl = Datalake(env=args.env, log_level=args.loglevel)
+    spinner = None
+    if logger.isEnabledFor(logging.INFO):
+        spinner = Halo(text=f'Parsing input...', spinner='dots')
+        spinner.start()
     hashkey_only = args.hashkey_only
     untyped_atoms = args.untyped_atoms or []
     size_limit = 100
@@ -109,20 +115,24 @@ def main(override_args=None):
 
     # Query each atom type
     full_response = {}
+    if spinner:
+        spinner.text = f'Executing bulk search...'
     for atom_type, atoms in typed_atoms_to_look_up.items():
         response = dtl.Threats.bulk_lookup(
             atom_values=atoms,
             atom_type=AtomType[atom_type.upper()],
             hashkey_only=hashkey_only,
             output=output_type,
+            return_search_hashkey=True
         )
         full_response = aggregate_csv_or_json_api_response(full_response, response)
-
+    if spinner:
+        spinner.succeed('Done.')
     if args.output:
         save_output(args.output, full_response)
         logger.debug(f'Results saved in {args.output}\n')
     else:
-        pretty_print(full_response, args.output_type)
+        pretty_print(full_response, args.output_type, args.env, dtl)
     logger.debug(f'END: lookup_threats.py')
 
 
@@ -162,7 +172,7 @@ def get_atom_type_from_filename(filename, input_delimiter=':'):
     exit(1)
 
 
-def pretty_print(raw_response, stdout_format):
+def pretty_print(raw_response, stdout_format, env, dtl):
     """
      takes the API raw response and format it for be printed as stdout
      stdout_format possible values {json, csv}
@@ -175,23 +185,33 @@ def pretty_print(raw_response, stdout_format):
         logger.info(raw_response)
         return
 
+    search_hashkeys = raw_response['search_hashkey'] if 'search_hashkey' in raw_response else None
+    raw_response.pop('search_hashkey')
     blue_bg = '\033[104m'
     eol = '\x1b[0m'
     boolean_to_text_and_color = {
         True: ('FOUND', '\x1b[6;30;42m'),
         False: ('NOT_FOUND', '\x1b[6;30;41m')
     }
+    parsed_url = urlparse(dtl.Threats.endpoint_config['main'][env])
+    base_url = f'{parsed_url.scheme}://{parsed_url.netloc}/gui/?query_hash='
     for atom_type in raw_response.keys():
         logger.info(
-            f'{blue_bg}{"#" * 60} {atom_type.upper()} {"#" * (60 - len(atom_type))}{eol}')
+            f'\x1b[6;30;41m{blue_bg}{"#" * 50} {atom_type.upper()} {"#" * (50 - len(atom_type))}{eol}\x1b[0m')
 
         for atom in raw_response[atom_type]:
             found = atom.get('threat_found', False)
             text, color = boolean_to_text_and_color[found]
             logger.info(
-                f'{atom_type} {atom["atom_value"]} hashkey: {atom["hashkey"]} {color} {text} {eol}')
+                f'{atom_type : <11} {atom["atom_value"][:29] : <30} hashkey: {atom["hashkey"]} {color} {text :^15} {eol}')
 
         logger.info('')
+    if search_hashkeys and len(search_hashkeys) <= 10:
+        for search_hashkey in search_hashkeys:
+            url = base_url + search_hashkey
+            logger.info(f'Results available here : {url}')
+    else:
+        logger.info('To many search hashkeys to display, check the output for the full list.')
 
 
 if __name__ == '__main__':

--- a/datalake_scripts/scripts/bulk_lookup_threats.py
+++ b/datalake_scripts/scripts/bulk_lookup_threats.py
@@ -181,7 +181,6 @@ def pretty_print(raw_response, stdout_format):
         True: ('FOUND', '\x1b[6;30;42m'),
         False: ('NOT_FOUND', '\x1b[6;30;41m')
     }
-
     for atom_type in raw_response.keys():
         logger.info(
             f'{blue_bg}{"#" * 60} {atom_type.upper()} {"#" * (60 - len(atom_type))}{eol}')

--- a/docs/Bulk_lookup_threats.md
+++ b/docs/Bulk_lookup_threats.md
@@ -1,4 +1,4 @@
-# Returns weather or not threats are in the database
+# Returns whether threats are in the database or not
 
 ### Using input files
 This command can read one or multiple files at the same time as atom input. To pass them, using `-i` or `--input` 
@@ -24,10 +24,10 @@ You can pass files as typed or untyped, it means that you will indicate which ki
   ```
 
   ```shell
-  $ ocd-dt bulk_lookup_threats -i ip:path/to/file/myiplist.txt -i file:path/to/file/myfilelist.txt
+  $ ocd-dtl bulk_lookup_threats -i ip:path/to/file/myiplist.txt -i file:path/to/file/myfilelist.txt
                                   --------- ip typed ---------    --------- file typed -----------
                                   
-  $ ocd-dt bulk_lookup_threats -i path/to/file/myatomlist.txt
+  $ ocd-dtl bulk_lookup_threats -i path/to/file/myatomlist.txt
                                   --------- untyped ---------
   ```
 
@@ -36,18 +36,18 @@ As input files, you can pass one or multiple **typed** or **untyped** atoms by C
 
 * **typed atoms**: Each atom has its own flag called exactly the same as the atom type.
   ```shell
-  $ ocd-dt bulk_lookup_threats --ip 113.223.40.103 --ip 5.78.23.158 --domain reverso.net  --file f0f5d30e91006c8ca7a528f26432ftt5 
+  $ ocd-dtl bulk_lookup_threats --ip 113.223.40.103 --ip 5.78.23.158 --domain reverso.net  --file f0f5d30e91006c8ca7a528f26432ftt5 
   ```     
 
 * **untyped atoms**: If you don't know the atom type, pass them as positional arguments, and the command will find out its type. 
   ```shell
-  $ ocd-dt bulk_lookup_threats 113.223.40.103 5.78.23.158 reverso.net f0f5d30e91006c8ca7a528f26432ftt5 
+  $ ocd-dtl bulk_lookup_threats 113.223.40.103 5.78.23.158 reverso.net f0f5d30e91006c8ca7a528f26432ftt5 
   ```     
   
 
 With all that in mind, you can combine them to fit your needs:
 ```shell
-$ ocd-dt bulk_lookup_threats reverso.net 113.223.40.103 --domain paiza.com --ip 45.96.65.132 -i ip:path/to/file/myiplist.txt -i path/to/file/myfilelist.txt
+$ ocd-dtl bulk_lookup_threats reverso.net 113.223.40.103 --domain paiza.com --ip 45.96.65.132 -i ip:path/to/file/myiplist.txt -i path/to/file/myfilelist.txt
                              ----untyped domain ip----- ---typed domain--- ----typed ip----  -------typed file as ip-------- ---------untyped file---------                                                
 ```
 

--- a/tests/lib/test_threats.py
+++ b/tests/lib/test_threats.py
@@ -422,5 +422,5 @@ def test_add_threats_no_bulk(datalake: Datalake):
 
     atom_list = ['11.11.111.1']
     threat_types = [{'threat_type': ThreatType('ddos'), 'score': 0}]
-    assert datalake.Threats.add_threats(atom_list, AtomType.IP, threat_types, OverrideType.TEMPORARY, no_bulk=True) == [
-        resp]
+    assert datalake.Threats.add_threats(atom_list, AtomType.IP, threat_types, OverrideType.TEMPORARY, no_bulk=True) \
+           == [resp]

--- a/tutorial.md
+++ b/tutorial.md
@@ -62,7 +62,8 @@ dtl.Threats.bulk_lookup(
     atom_values=threats, 
     atom_type=AtomType.DOMAIN,
     hashkey_only=False,
-    output=Output.CSV
+    output=Output.CSV,
+    return_search_hashkey=False
 )
 ```
 


### PR DESCRIPTION
Added url to GUI from a bulk_lookup if there is less than 10 search_hashkeys.
Added a return_search_hashkey parameter for the above changes to bulk_lookup function and reflected the changes in the documentation.
Wrote a test for the new parameter.
Updated output to be more readable.