### PR TITLE
#56 Advanced_search_from_query_body: wrong type for ordering

### DIFF
--- a/datalake/endpoints/advanced_search.py
+++ b/datalake/endpoints/advanced_search.py
@@ -1,6 +1,7 @@
 from datalake.endpoints.endpoint import Endpoint
 from datalake.common.ouput import parse_response, Output, output_supported
 from requests.sessions import PreparedRequest
+from typing import List
 
 
 class AdvancedSearch(Endpoint):
@@ -9,33 +10,45 @@ class AdvancedSearch(Endpoint):
 
     @output_supported({Output.JSON, Output.STIX, Output.MISP, Output.CSV})
     def advanced_search_from_query_body(self, query_body: dict, limit: int = 20, offset: int = 0, 
-                                        ordering=None, output=Output.JSON):
+                                        ordering: List[str] = None, output=Output.JSON):
         if not query_body:
             raise ValueError("query_body is required")
-        if ordering and ordering not in self.ordering_list:
-            raise ValueError(f'ordering needs to be one of the following str : {", ".join(self.ordering_list)}')
+        if ordering and not isinstance(ordering, list):
+            raise ValueError(
+                f'ordering needs to be a list of at least one of the following str : {", ".join(self.ordering_list)}'
+            )
+        if ordering and not set(ordering).issubset(self.ordering_list):
+            raise ValueError(
+                f'ordering needs to be a list of at least one of the following str : {", ".join(self.ordering_list)}'
+            )
         body = {
             'query_body': query_body,
             'limit': limit,
             'offset': offset,
         }
         if ordering:
-            body['ordering'] = [ordering]
+            body['ordering'] = ordering
         url = self._build_url_for_endpoint('advanced-search')
         response = self.datalake_requests(url, 'post', post_body=body, headers=self._post_headers(output=output))
         return parse_response(response)
 
     @output_supported({Output.JSON, Output.STIX, Output.MISP, Output.CSV})
     def advanced_search_from_query_hash(self, query_hash, limit: int = 20, offset: int = 0,
-                                        ordering=None, output=Output.JSON):
+                                        ordering: List[str] = None, output=Output.JSON):
         if not query_hash:
             raise ValueError("query_hash is required")
-        if ordering and ordering not in self.ordering_list:
-            raise ValueError(f'ordering needs to be one of the following str : {", ".join(self.ordering_list)}')
+        if ordering and not isinstance(ordering, list):
+            raise ValueError(
+                f'ordering needs to be a list of at least one of the following str : {", ".join(self.ordering_list)}'
+            )
+        if ordering and not set(ordering).issubset(self.ordering_list):
+            raise ValueError(
+                f'ordering needs to be a list of at least one of the following str : {", ".join(self.ordering_list)}'
+            )
         url = self._build_url_for_endpoint('advanced-search-hash').format(query_hash=query_hash)
         params = {'limit': limit, 'offset': offset}
         if ordering:
-            params['ordering'] = [ordering]
+            params['ordering'] = ordering
         req = PreparedRequest()
         req.prepare_url(url, params)
         url = req.url

--- a/datalake/endpoints/advanced_search.py
+++ b/datalake/endpoints/advanced_search.py
@@ -4,7 +4,7 @@ from requests.sessions import PreparedRequest
 
 
 class AdvancedSearch(Endpoint):
-    ordering_list = ['first_seen', '-first-seen', 'last_updated', '-last_updated', 'events_count', '-events_count',
+    ordering_list = ['first_seen', '-first_seen', 'last_updated', '-last_updated', 'events_count', '-events_count',
                      'sources_count', '-sources_count']
 
     @output_supported({Output.JSON, Output.STIX, Output.MISP, Output.CSV})
@@ -20,7 +20,7 @@ class AdvancedSearch(Endpoint):
             'offset': offset,
         }
         if ordering:
-            body['ordering'] = ordering
+            body['ordering'] = [ordering]
         url = self._build_url_for_endpoint('advanced-search')
         response = self.datalake_requests(url, 'post', post_body=body, headers=self._post_headers(output=output))
         return parse_response(response)
@@ -33,7 +33,9 @@ class AdvancedSearch(Endpoint):
         if ordering and ordering not in self.ordering_list:
             raise ValueError(f'ordering needs to be one of the following str : {", ".join(self.ordering_list)}')
         url = self._build_url_for_endpoint('advanced-search-hash').format(query_hash=query_hash)
-        params = {'limit': limit, 'offset': offset, 'ordering': ordering}
+        params = {'limit': limit, 'offset': offset}
+        if ordering:
+            params['ordering'] = [ordering]
         req = PreparedRequest()
         req.prepare_url(url, params)
         url = req.url

--- a/datalake/endpoints/advanced_search.py
+++ b/datalake/endpoints/advanced_search.py
@@ -13,10 +13,6 @@ class AdvancedSearch(Endpoint):
                                         ordering: List[str] = None, output=Output.JSON):
         if not query_body:
             raise ValueError("query_body is required")
-        if ordering and not isinstance(ordering, list):
-            raise ValueError(
-                f'ordering needs to be a list of at least one of the following str : {", ".join(self.ordering_list)}'
-            )
         if ordering and not set(ordering).issubset(self.ordering_list):
             raise ValueError(
                 f'ordering needs to be a list of at least one of the following str : {", ".join(self.ordering_list)}'
@@ -37,10 +33,6 @@ class AdvancedSearch(Endpoint):
                                         ordering: List[str] = None, output=Output.JSON):
         if not query_hash:
             raise ValueError("query_hash is required")
-        if ordering and not isinstance(ordering, list):
-            raise ValueError(
-                f'ordering needs to be a list of at least one of the following str : {", ".join(self.ordering_list)}'
-            )
         if ordering and not set(ordering).issubset(self.ordering_list):
             raise ValueError(
                 f'ordering needs to be a list of at least one of the following str : {", ".join(self.ordering_list)}'

--- a/datalake_scripts/scripts/advanced_search.py
+++ b/datalake_scripts/scripts/advanced_search.py
@@ -59,10 +59,10 @@ def main(override_args=None):
     if args.input:
         query_body = load_json(args.input)
         resp = dtl.AdvancedSearch.advanced_search_from_query_body(query_body, limit=args.limit, offset=args.offset,
-                                                                  output=output_type, ordering=args.ordering)
+                                                                  output=output_type, ordering=[args.ordering])
     else:
         resp = dtl.AdvancedSearch.advanced_search_from_query_hash(args.query_hash, limit=args.limit, offset=args.offset,
-                                                                  output=output_type, ordering=args.ordering)
+                                                                  output=output_type, ordering=[args.ordering])
     save_output(args.output, resp)
     logger.info(f'\x1b[0;30;42m OK: MATCHING THREATS SAVED IN {args.output} \x1b[0m')
     logger.debug(f'END: advanced_search.py')

--- a/tests/lib/test_advanced_search.py
+++ b/tests/lib/test_advanced_search.py
@@ -45,12 +45,12 @@ def mock_api_resp():
     responses.add(
         responses.GET,
         'https://datalake.cert.orangecyberdefense.com/api/v2/mrti/advanced-queries/threats'
-        '/8697fbe09069e882e2de169ad480c2bf/?limit=0&offset=0', 
+        '/8697fbe09069e882e2de169ad480c2bf/?limit=0&offset=0',
         status=200,
         json={
             "count": 1,
             "href_query": "https://datalake.cert.orangecyberdefense.com/api/v2/mrti/advanced-queries/threats"
-                          "/8697fbe09069e882e2de169ad480c2bf/66ec37c2032d1b/", 
+                          "/8697fbe09069e882e2de169ad480c2bf/66ec37c2032d1b/",
             "query_body": query_body,
             "query_hash": "8697fbe09069e882e2de169ad480c2bf",
             "results": []
@@ -100,14 +100,22 @@ def test_advanced_search_from_query_hash_no_hash(datalake: Datalake):
 
 def test_advanced_search_from_query_hash_bad_ordering(datalake: Datalake):
     with pytest.raises(ValueError) as exec_error:
+        datalake.AdvancedSearch.advanced_search_from_query_hash(query_hash, limit=0, ordering=['badbad'])
+    assert str(exec_error.value) == "ordering needs to be a list of at least one of the following str : first_seen, " \
+                                    "-first_seen, last_updated, -last_updated, events_count, -events_count, " \
+                                    "sources_count, -sources_count"
+
+
+def test_advanced_search_from_query_hash_ordering_not_list(datalake: Datalake):
+    with pytest.raises(ValueError) as exec_error:
         datalake.AdvancedSearch.advanced_search_from_query_hash(query_hash, limit=0, ordering='badbad')
-    assert str(exec_error.value) == "ordering needs to be one of the following str : first_seen, -first_seen, " \
-                                    "last_updated, -last_updated, events_count, -events_count, sources_count, " \
-                                    "-sources_count"
+    assert str(exec_error.value) == "ordering needs to be a list of at least one of the following str : first_seen, " \
+                                    "-first_seen, last_updated, -last_updated, events_count, -events_count, " \
+                                    "sources_count, -sources_count"
 
 
 @responses.activate
 def test_advanced_search_from_query_hash_ok_ordering(datalake: Datalake):
     mock_api_resp()
-    resp = datalake.AdvancedSearch.advanced_search_from_query_hash(query_hash, limit=0, ordering='first_seen')
+    resp = datalake.AdvancedSearch.advanced_search_from_query_hash(query_hash, limit=0, ordering=['first_seen'])
     assert resp['query_hash'] == query_hash

--- a/tests/lib/test_advanced_search.py
+++ b/tests/lib/test_advanced_search.py
@@ -101,7 +101,7 @@ def test_advanced_search_from_query_hash_no_hash(datalake: Datalake):
 def test_advanced_search_from_query_hash_bad_ordering(datalake: Datalake):
     with pytest.raises(ValueError) as exec_error:
         datalake.AdvancedSearch.advanced_search_from_query_hash(query_hash, limit=0, ordering='badbad')
-    assert str(exec_error.value) == "ordering needs to be one of the following str : first_seen, -first-seen, " \
+    assert str(exec_error.value) == "ordering needs to be one of the following str : first_seen, -first_seen, " \
                                     "last_updated, -last_updated, events_count, -events_count, sources_count, " \
                                     "-sources_count"
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -247,7 +247,7 @@ query_hash = 'cece3117abc823cee81e69c2143e6268'
 adv_search_hash_resp = dtl.AdvancedSearch.advanced_search_from_query_hash(query_hash, limit=20, offset=0, 
                                                                           ordering='first_seen', output=Output.JSON)
 
-adv_search_body_resp = dtl.AdvancedSearch.advanced_search_from_query_body(query_bodylimit=20, offset=0, 
+adv_search_body_resp = dtl.AdvancedSearch.advanced_search_from_query_body(query_body, limit=20, offset=0, 
                                                                           ordering='-first_seen', output=Output.JSON)
 ````
 ### Sightings

--- a/tutorial.md
+++ b/tutorial.md
@@ -245,10 +245,10 @@ query_body = {
 query_hash = 'cece3117abc823cee81e69c2143e6268'
 
 adv_search_hash_resp = dtl.AdvancedSearch.advanced_search_from_query_hash(query_hash, limit=20, offset=0, 
-                                                                          ordering='first_seen', output=Output.JSON)
+                                                                          ordering=['first_seen'], output=Output.JSON)
 
 adv_search_body_resp = dtl.AdvancedSearch.advanced_search_from_query_body(query_body, limit=20, offset=0, 
-                                                                          ordering='-first_seen', output=Output.JSON)
+                                                                          ordering=['-first_seen'], output=Output.JSON)
 ````
 ### Sightings
 Sightings can be submitted using the library using a list of atoms:


### PR DESCRIPTION
Fixed mistake in tutorial.md section for advanced search,
Fixed mistake in ordering list available options and corrected the variable type sent to the API