### PR TITLE
MRTI-4753 # Updated behavior for 422 code response from the API

### DIFF
--- a/datalake/endpoints/endpoint.py
+++ b/datalake/endpoints/endpoint.py
@@ -70,9 +70,15 @@ class Endpoint:
                 logger.warning('Token expired or Missing authorization header. Updating token')
                 self.token_manager.process_auth_error(response.json().get('msg'))
             elif response.status_code == 422:
-                logger.warning('Bad authorization header. Updating token')
-                logger.debug(f'422 HTTP code: {response.text}')
-                self.token_manager.process_auth_error(response.json().get('messages'))
+                if "msg" in response.json():
+                    logger.error(f'Error message: {response.json().get("msg")}')
+                elif "message" in response.json():
+                    logger.error(f'Error message: {response.json().get("message")}')
+                elif "messages" in response.json():
+                    logger.error(f'Error message: {response.json().get("messages")}')
+                else:
+                    logger.error(f'422 HTTP code: {response.text}')
+                break
             elif response.status_code < 200 or response.status_code > 299:
                 logger.error(
                     f'API returned non 2xx response code : {response.status_code}\n{response.text}\n Retrying'


### PR DESCRIPTION
When the API responded with a 422 code, the CLI would inform the user that his authorization header was bad and would attempt to update it. This behavior probably matched the old behavior of the old API that has since been updated.
The API now sends a 422 when it fails to validate the parameters of the request. User would get misleading message on the origin of the problem when they had a bad request. Authorization header errors use the 401 error code.

Different requests also have different keys in their error responds on code 422 depending on where the failure happened.

Updated the CLI to match the new API behavior described above.
Bad requests no longer inform the user that their authorization header is bad and now prints the error message sent back from the API.
